### PR TITLE
Update Vagrantfile to include X11 Forwarding (ssh)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,6 +50,11 @@ Vagrant.configure(2) do |config|
   #   # Display the VirtualBox GUI when booting the machine
      vb.gui = true
   #
+  # Enable ssh x11 forwarding : ssh -X ... set to true to enable.
+  # It is suggested to set vb.gui = false
+  # if you don't need the console while x forwarding is enabled
+  config.ssh.forward_x11 = true
+
   #   # Customize the amount of memory on the VM:
      vb.memory = "5025"
    end


### PR DESCRIPTION
Enables X11 Forwarding.

This means that all you need is an X server, XQuartz on Mac OS X for example, to run gui apps from your vagrant.

Simply run "vagrant ssh" like normal and then run your gui program. 

Example: 
$ sudo apt-get install gedit
$ gedit
