### PR TITLE
Added vagrant-cachier feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ http://laravel.com/docs/5.0/homestead
  * Ruby: https://github.com/joshfng/railsready
 
 # Getting Started:
-### To speed up your vagrant reloads with vagrant-cachier to locally store apt, deb, etc. Make sure you have Vagrant 1.4+ and run : 
+### Tip:
+To speed up your vagrant reloads with vagrant-cachier to locally store apt, deb, etc. Make sure you have Vagrant 1.4+ and run : 
 vagrant plugin install vagrant-cachier
 
-### To install and run 'dotVagrant' --> Run this: 
+### To run 'dotVagrant' Run this: 
 git clone https://github.com/joshmccall221/dotvagrant.git && cd ./dotvagrant && vagrant up && vagrant reload
 
 #### Resources:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ http://laravel.com/docs/5.0/homestead
  * Ruby: https://github.com/joshfng/railsready
 
 # Getting Started:
-### Run this: 
+### To speed up your vagrant reloads with vagrant-cachier to locally store apt, deb, etc. Make sure you have Vagrant 1.4+ and run : 
+vagrant plugin install vagrant-cachier
+
+### To install and run 'dotVagrant' --> Run this: 
 git clone https://github.com/joshmccall221/dotvagrant.git && cd ./dotvagrant && vagrant up && vagrant reload
 
 #### Resources:
@@ -57,8 +60,11 @@ git clone https://github.com/joshmccall221/dotvagrant.git && cd ./dotvagrant && 
 * https://gist.github.com/fundon/1150782
 * http://blog.csanchez.org/2012/05/03/automatically-download-and-install-virtualbox-guest-additions-in-vagrant/
 * https://github.com/mitchellh/vagrant/issues/3341
+* https://github.com/fgrehm/vagrant-cachier
+
 #### zsh powerlines:
 https://github.com/jeremyFreeAgent/oh-my-zsh-powerline-theme
+
 
 ###Centos
 * http://apetec.com/linux/InstallVIM.htm

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,6 +21,14 @@ Vagrant.configure(2) do |config|
   # `vagrant box outdated`. This is not recommended.
   # config.vm.box_check_update = false
 
+  # start of vagrant-cachier
+  # https://github.com/fgrehm/vagrant-cachier
+  if Vagrant.has_plugin?("vagrant-cachier")
+    config.cache.scope = :box
+  end
+  # end of vagrant-cachier
+
+
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.


### PR DESCRIPTION
With this code, anyone who has installed the vagrant-cachier plugin can save time on vagrant up.
Install plugin to enable the feature:
vagrant plugin install vagrant-cachier

The lines added to dotVagrant autodetect the plugin and will then enable the caching.

Party On Dudes!
